### PR TITLE
feat: Add Lint rule for missing @CollectableEventsData annotation

### DIFF
--- a/DemoApp/src/main/java/com/nodrex/eventscollectordemo/MainActivity.kt
+++ b/DemoApp/src/main/java/com/nodrex/eventscollectordemo/MainActivity.kt
@@ -73,8 +73,7 @@ private fun testLib() {
 
     collector.emit(TaskData::age, "30")
     collector.emit(TaskData::status, 125)
-
-    collector.emit(TaskData::age, "asdas")
+    collector.emit(TaskData::age, "stringAge")
 
 }
 

--- a/EventsCollectorLib/build.gradle.kts
+++ b/EventsCollectorLib/build.gradle.kts
@@ -39,15 +39,12 @@ android {
 
 dependencies {
     lintPublish(project(":Lint")) // Publish lint rules to be used by other modules
-
     implementation(project(":Annotations")) // The library needs to know about the annotation to be used on its data classes
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
+
     implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/Lint/build.gradle.kts
+++ b/Lint/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("java-library")
+    alias(libs.plugins.jetbrains.kotlin.jvm)
+}
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
+
+dependencies {
+    compileOnly(libs.lint.api)
+    compileOnly(libs.kotlin.stdlib.jdk8)
+
+    // Optional: For testing lint rules
+    testImplementation(libs.lint.tests)
+    testImplementation(libs.junit)
+}
+
+// Create lint JAR with proper manifest
+tasks.named<Jar>("jar") {
+    manifest {
+        attributes["Lint-Registry-v2"] = "com.nodrex.eventscollector.lint.EventsCollectorIssueRegistry"
+    }
+}

--- a/Lint/src/main/java/com/nodrex/eventscollector/lint/AnnotationDetector.kt
+++ b/Lint/src/main/java/com/nodrex/eventscollector/lint/AnnotationDetector.kt
@@ -1,0 +1,65 @@
+package com.nodrex.eventscollector.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.*
+import com.intellij.psi.PsiClassType
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+
+class AnnotationDetector : Detector(), SourceCodeScanner {
+
+    companion object {
+        val ISSUE = Issue.create(
+            id = "MissingCollectableAnnotation",
+            briefDescription = "Class is missing @CollectableEventsData annotation",
+            explanation = """
+                Any class used with the EventsCollector must be annotated with [@CollectableEventsData].
+                This allows the KSP processor to validate data class.
+            """,
+            category = Category.CORRECTNESS,
+            priority = 10,
+            severity = Severity.FATAL,
+            implementation = Implementation(AnnotationDetector::class.java, Scope.JAVA_FILE_SCOPE)
+        )
+    }
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> {
+        // We want to inspect function calls.
+        return listOf(UCallExpression::class.java)
+    }
+
+    override fun createUastHandler(context: JavaContext): UElementHandler {
+        return object : UElementHandler() {
+            override fun visitCallExpression(node: UCallExpression) {
+                val resolvedMethod = node.resolve() ?: return
+
+                // Check if the method is one of our factory functions.
+                if (resolvedMethod.containingClass?.qualifiedName != LibInfo.EVENTS_COLLECTOR_COMPANION_PATH ||
+                    node.methodName !in listOf(
+                        LibInfo.START_FUNCTION_NAME,
+                        LibInfo.START_SINGLE_COLLECTOR_FUNCTION_NAME
+                    )
+                ) {
+                    return
+                }
+
+                // Get the first generic type argument passed to the function (e.g., the 'UserData' in start<UserData>(...)).
+                val typeArgument = node.typeArguments.firstOrNull() ?: return
+                val resolvedClass = (typeArgument as? PsiClassType)?.resolve() ?: return
+
+                // Check if the resolved class has our required annotation.
+                val hasAnnotation =
+                    resolvedClass.hasAnnotation(LibInfo.ANNOTATION_CLASS_PATH)
+
+                if (!hasAnnotation) {
+                    context.report(
+                        ISSUE,
+                        node,
+                        context.getLocation(node),
+                        "The class [${resolvedClass.name}] must be annotated with [@CollectableEventsData] to be used with EventsCollector."
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Lint/src/main/java/com/nodrex/eventscollector/lint/EmitTypeCheckDetector.kt
+++ b/Lint/src/main/java/com/nodrex/eventscollector/lint/EmitTypeCheckDetector.kt
@@ -17,9 +17,12 @@ class EmitTypeCheckDetector : Detector(), SourceCodeScanner {
                 This check ensures type safety at build time.
             """,
             category = Category.CORRECTNESS,
-            priority = 6,
-            severity = Severity.ERROR,
-            implementation = Implementation(EmitTypeCheckDetector::class.java, Scope.JAVA_FILE_SCOPE)
+            priority = 10,
+            severity = Severity.FATAL,
+            implementation = Implementation(
+                EmitTypeCheckDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
         )
     }
 
@@ -30,9 +33,9 @@ class EmitTypeCheckDetector : Detector(), SourceCodeScanner {
     override fun createUastHandler(context: JavaContext): UElementHandler {
         return object : UElementHandler() {
             override fun visitCallExpression(node: UCallExpression) {
-                if (node.methodName != "emit") return
+                if (node.methodName != LibInfo.EMIT_FUNCTION_NAME) return
                 val resolvedMethod = node.resolve() ?: return
-                if (resolvedMethod.containingClass?.qualifiedName != "com.nodrex.eventscollector.EventsCollector") return
+                if (resolvedMethod.containingClass?.qualifiedName != LibInfo.EVENTS_COLLECTOR_CLASS_PATH) return
                 if (node.valueArgumentCount != 2) return
 
                 val propertyArgumentType = node.valueArguments[0].getExpressionType() ?: return

--- a/Lint/src/main/java/com/nodrex/eventscollector/lint/EventsCollectorIssueRegistry.kt
+++ b/Lint/src/main/java/com/nodrex/eventscollector/lint/EventsCollectorIssueRegistry.kt
@@ -5,7 +5,7 @@ import com.android.tools.lint.detector.api.Issue
 
 
 class EventsCollectorIssueRegistry : IssueRegistry() {
-    override val issues: List<Issue> = listOf(EmitTypeCheckDetector.ISSUE)
+    override val issues: List<Issue> = listOf(EmitTypeCheckDetector.ISSUE, AnnotationDetector.ISSUE)
 
     override val api: Int = com.android.tools.lint.detector.api.CURRENT_API
 }

--- a/Lint/src/main/java/com/nodrex/eventscollector/lint/LibInfo.kt
+++ b/Lint/src/main/java/com/nodrex/eventscollector/lint/LibInfo.kt
@@ -1,0 +1,14 @@
+package com.nodrex.eventscollector.lint
+
+object LibInfo {
+    const val EVENTS_COLLECTOR_PACKAGE_PATH = "com.nodrex.eventscollector"
+    const val EVENTS_COLLECTOR_CLASS_PATH = "$EVENTS_COLLECTOR_PACKAGE_PATH.EventsCollector"
+    const val EVENTS_COLLECTOR_COMPANION_PATH =
+        "$EVENTS_COLLECTOR_PACKAGE_PATH.EventsCollector.Companion"
+    const val ANNOTATION_CLASS_PATH =
+        "$EVENTS_COLLECTOR_PACKAGE_PATH.annotations.CollectableEventsData"
+
+    const val EMIT_FUNCTION_NAME = "emit"
+    const val START_FUNCTION_NAME = "start"
+    const val START_SINGLE_COLLECTOR_FUNCTION_NAME = "startSingleCollector"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,25 +1,23 @@
 [versions]
 agp = "8.10.1"
 ksp = "2.0.0-1.0.21"
-coreKtx = "1.16.0"
+kotlin = "2.0.0"
 coroutines = "1.8.1"
+lint = "31.10.1"
+
 lifecycleRuntimeKtx = "2.9.2"
+coreKtx = "1.16.0"
 activityCompose = "1.10.1"
 composeBom = "2025.07.00"
-
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-jetbrainsKotlinJvm = "2.0.0"
-appcompat = "1.7.1"
-material = "1.12.0"
+
 
 [libraries]
+# Dependencies for the demo project
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-
-
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
@@ -30,24 +28,27 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "jetbrainsKotlinJvm" }
+# Lib dependencies
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
+lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 
-
+# Test dependencies
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
 
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "jetbrainsKotlinJvm" }
-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "jetbrainsKotlinJvm" }
+# Lib Plugins
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvm" }
+jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit introduces a new Lint rule to the `Lint` module.

**AnnotationDetector (`AnnotationDetector.kt`):**
- This detector checks if classes used as generic type arguments in `EventsCollector.start()` or `EventsCollector.startSingleCollector()` are annotated with `@CollectableEventsData`.
- If a class is not annotated, it reports a FATAL error: "The class [...] must be annotated with [@CollectableEventsData] to be used with EventsCollector."
- The issue ID for this rule is `MissingCollectableAnnotation`.

**Configuration and Integration:**
- Added `AnnotationDetector.ISSUE` to `EventsCollectorIssueRegistry.kt`.
- Created `LibInfo.kt` to store common string constants used by the Lint rules (e.g., class paths, function names).
- Updated `EmitTypeCheckDetector.kt` to use constants from `LibInfo.kt` and increased its severity to FATAL.
- Configured the `Lint/build.gradle.kts` file:
    - Added dependencies for `lint-api`, `kotlin-stdlib-jdk8`, and test dependencies for Lint.
    - Configured the JAR manifest to include `Lint-Registry-v2` pointing to `com.nodrex.eventscollector.lint.EventsCollectorIssueRegistry`.
- Updated `EventsCollectorLib/build.gradle.kts` to publish the Lint rules via `lintPublish(project(":Lint"))`.
- Updated `gradle/libs.versions.toml`:
    - Added `lint` and `kotlin` versions.
    - Added library aliases for `lint-api`, `kotlin-stdlib-jdk8`, and `lint-tests`.
    - Unified Kotlin plugin versions under the `kotlin` version.

**DemoApp:**
- Slightly modified a value in `MainActivity.kt` for testing purposes.