### PR TITLE
Refactor: Change Annotations dependency from implementation to api

### DIFF
--- a/EventsCollectorLib/build.gradle.kts
+++ b/EventsCollectorLib/build.gradle.kts
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     lintPublish(project(":Lint")) // Publish lint rules to be used by other modules
-    implementation(project(":Annotations")) // The library needs to know about the annotation to be used on its data classes
+    api(project(":Annotations")) // The library needs to know about the annotation to be used on its data classes
 
     implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)


### PR DESCRIPTION
This commit updates the `EventsCollectorLib/build.gradle.kts` file. The dependency on the `:Annotations` project has been changed from `implementation` to `api`. This makes the annotations defined in the `:Annotations` module available to consumers of `EventsCollectorLib`.